### PR TITLE
Render pretty product attributes on product detail page

### DIFF
--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -1,6 +1,9 @@
+import json
+
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render
+
 from .models import Product
 
 def home(request):
@@ -19,4 +22,8 @@ def product_list(request):
 
 def product_detail(request, slug):
     p = get_object_or_404(Product, slug=slug)
-    return render(request, 'catalog/detail.html', { 'p': p })
+    attributes_pretty = json.dumps(p.attributes, ensure_ascii=False, indent=2)
+    return render(request, 'catalog/detail.html', {
+        'p': p,
+        'attributes_pretty': attributes_pretty,
+    })

--- a/backend/templates/catalog/detail.html
+++ b/backend/templates/catalog/detail.html
@@ -26,7 +26,8 @@
     <div class="mt-6 grid sm:grid-cols-2 gap-3">
       <div class="card rounded-xl p-4">
         <div class="text-sm text-white/60 mb-1">Thuộc tính</div>
-        <pre class="text-xs whitespace-pre-wrap text-white/70">{{ p.attributes|json_script:"attr" }}</pre>
+        <pre class="text-xs whitespace-pre-wrap text-white/70">{{ attributes_pretty }}</pre>
+        {{ p.attributes|json_script:"attr" }}
       </div>
       <div class="card rounded-xl p-4">
         <div class="text-sm text-white/60 mb-1">Mô tả</div>


### PR DESCRIPTION
## Summary
- pretty-print product attribute JSON before rendering
- pass formatted attributes to the product detail template and keep a JSON script tag for JS usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba7dbdb1c832eb9f4ec830cf85c33